### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This is the ACCESS Post-Processor (APP), version 4.1
 Initially created by Peter Uhe for CMIP5, and further developed for CMIP6-era by Chloe Mackallah.  
 CSIRO, O&A Aspendale.
 
-CSIRO DAP: http://hdl.handle.net/102.100.100/437645?index=1
+This repository was iniated from the orginal (and no-longer active) NCI GitLab repo https://git.nci.org.au/cm2704/APP4 on 9 March, 2023.  
+For the authoritative version of this code as used for the post-production of ACCESS datasets for CMIP6 (stored in fs38 on NCI's Gadi), see https://doi.org/10.5281/zenodo.7703469.  
+CSIRO DAP record: http://hdl.handle.net/102.100.100/437645?index=1
 
 ---
 


### PR DESCRIPTION
Adding provenance to readme, linking to original GitLab repo, and CMIP6-era authoritative Zenodo DOI.